### PR TITLE
Detect file type automatically based on extension

### DIFF
--- a/ftdetect/asciidoc.vim
+++ b/ftdetect/asciidoc.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufReadPost *.asciidoc,*.adoc,*.asc set filetype=asciidoc


### PR DESCRIPTION
As described on the recommended practices [1](http://asciidoctor.org/docs/asciidoc-recommended-practices/), the following extensions
are treated as Asciidoc documents:
- `*.asciidoc`
- `*.adoc`
- `*.asc`
