### PR TITLE
added folding

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -11,6 +11,17 @@ In addition to making reading AsciiDoc documents much easier, syntax highlightin
 This repository contains the Vim files necessary to syntax highlight AsciiDoc in Vim.
 A stable version of these files is included in the Vim distribution (see https://github.com/vim/vim/blob/master/runtime/syntax/asciidoc.vim[]).
 
+== Folding
+
+Folding on the section level is included as well.
+To enable the folding, add
+
+----
+let g:asciidoc_folding=1
+----
+
+to the `.vimrc` file.
+
 == Installation (development files)
 
 Install the highlighter by copying `asciidoc.vim` to your `$HOME/.vim/syntax` directory.

--- a/ftplugin/asciidoc.vim
+++ b/ftplugin/asciidoc.vim
@@ -1,0 +1,27 @@
+function! AsciidocFold()
+	let line = getline(v:lnum)
+	if (line =~ '\v^[a-zA-Z]')
+		let nextline = getline(v:lnum + 1)
+		if (strlen(nextline) != strlen(line))
+			return "="
+		endif
+		if (nextline =~ '\v^-+$')
+			return ">1"
+		endif
+		if (nextline =~ '\v^\~+$')
+			return ">2"
+		endif
+		if (nextline =~ '\v^\^+$')
+			return ">3"
+		endif
+		if (nextline =~ '\v^\++$')
+			return ">4"
+		endif
+	endif
+	return "="
+endfunction
+
+if has("folding") && exists("g:asciidoc_folding")
+  setlocal foldexpr=AsciidocFold()
+  setlocal foldmethod=expr
+endif

--- a/ftplugin/asciidoc.vim
+++ b/ftplugin/asciidoc.vim
@@ -4,17 +4,23 @@ function! AsciidocFold()
 		let nextline = getline(v:lnum + 1)
 		if (strlen(nextline) != strlen(line))
 			return "="
-		endif
-		if (nextline =~ '\v^-+$')
+		elseif (nextline =~ '\v^-+$')
 			return ">1"
-		endif
-		if (nextline =~ '\v^\~+$')
+		elseif (nextline =~ '\v^\~+$')
 			return ">2"
-		endif
-		if (nextline =~ '\v^\^+$')
+		elseif (nextline =~ '\v^\^+$')
 			return ">3"
+		elseif (nextline =~ '\v^\++$')
+			return ">4"
 		endif
-		if (nextline =~ '\v^\++$')
+	elseif (line =~ '\v^\=\=')
+		if (line =~ '\v^\=\=\s')
+			return ">1"
+		elseif (line =~ '\v^\=\=\=\s')
+			return ">2"
+		elseif (line =~ '\v^\=\=\=\s')
+			return ">3"
+		elseif (line =~ '\v^\=\=\=\=\s')
 			return ">4"
 		endif
 	endif

--- a/ftplugin/asciidoc.vim
+++ b/ftplugin/asciidoc.vim
@@ -4,6 +4,8 @@ function! AsciidocFold()
 		let nextline = getline(v:lnum + 1)
 		if (strlen(nextline) != strlen(line))
 			return "="
+		elseif (nextline =~ '\v^\=+$')
+			return ">0"
 		elseif (nextline =~ '\v^-+$')
 			return ">1"
 		elseif (nextline =~ '\v^\~+$')
@@ -13,8 +15,10 @@ function! AsciidocFold()
 		elseif (nextline =~ '\v^\++$')
 			return ">4"
 		endif
-	elseif (line =~ '\v^\=\=')
-		if (line =~ '\v^\=\=\s')
+	elseif (line =~ '\v^\=')
+		if (line =~ '\v^\=\s')
+			return ">0"
+		elseif (line =~ '\v^\=\=\s')
 			return ">1"
 		elseif (line =~ '\v^\=\=\=\s')
 			return ">2"
@@ -22,6 +26,13 @@ function! AsciidocFold()
 			return ">3"
 		elseif (line =~ '\v^\=\=\=\=\s')
 			return ">4"
+		endif
+	elseif (line =~ '\v^----$')
+		let prevline = getline(v:lnum - 1)
+		if (prevline[0] == "[")
+			return "a1"
+		else
+			return "s1"
 		endif
 	endif
 	return "="


### PR DESCRIPTION
The change enables optional folding in vim for setext-like section headers.

Like the default markdown style it can be enabled by setting g:asciidoc_folding